### PR TITLE
ec2: fixes for setting hostname at provisioning

### DIFF
--- a/plans/ec2.pp
+++ b/plans/ec2.pp
@@ -1,6 +1,6 @@
 plan bootstrap::ec2(
   TargetSpec $nodes,
-  Optional[String] $host_name = undef,
+  Optional[String] $host_name = 'auto',
 ) {
 
   $r = run_task(bootstrap::ec2_provision, $nodes, host_name => $host_name)
@@ -8,12 +8,12 @@ plan bootstrap::ec2(
   $nodes.apply_prep
 
   apply($nodes) {
-    if $host_name {
-      class { 'bootstrap::ec2': host_name => $host_name }
+    if $host_name == 'auto' {
+      class { 'bootstrap::ec2': }
       -> class { 'bootstrap': }
     }
     else {
-      class { 'bootstrap::ec2': }
+      class { 'bootstrap::ec2': host_name => $host_name }
       -> class { 'bootstrap': }
     }
   }

--- a/tasks/ec2_provision.sh
+++ b/tasks/ec2_provision.sh
@@ -5,7 +5,7 @@ public_ip=`/usr/bin/curl -s http://169.254.169.254/latest/meta-data/public-ipv4`
 
 # Derive hostname.
 # Unless we've been given a hostname to use, use the Public IP.
-if [ "$PT_host_name" == "" ] || [ "$PT_host_name" == "null"] ; then
+if [ "$PT_host_name" = "auto" ] ; then
   my_hostname=$(echo $public_ip | sed -e 's/\./-/g')
 else
   my_hostname=$PT_host_name


### PR DESCRIPTION
Plans run with `strict_variables` enabled so setting the `host_name` parameter to `undef` generates an `undefined variable` error.

This sets the default to `auto` in the ec2 plan and also fixes the comparison operators in the tests on `PT_host_name` in the ec2 task.